### PR TITLE
move weather tool to shareable poro

### DIFF
--- a/app/models/raif/model_tools/raif_weather_tool.rb
+++ b/app/models/raif/model_tools/raif_weather_tool.rb
@@ -73,15 +73,9 @@ module Raif
           # Extract arguments from tool_invocation.tool_arguments
           latitude = tool_invocation.tool_arguments["latitude"]
           longitude = tool_invocation.tool_arguments["longitude"]
-          # Process the invocation and perform the desired action
-          begin
-            url = "https://api.open-meteo.com/v1/forecast?temperature_unit=fahrenheit&latitude=#{latitude}&longitude=#{longitude}&current=temperature_2m,wind_speed_10m"
 
-            response = Faraday.get(url)
-            result = JSON.parse(response.body)
-          rescue => e
-            result = { error: e.message }
-          end
+          # Process the invocation using the shared weather service
+          result = WeatherService.fetch_weather(latitude: latitude, longitude: longitude)
 
           # Store the results in the tool_invocation
           tool_invocation.update!(

--- a/app/models/raix_helpful_assistant.rb
+++ b/app/models/raix_helpful_assistant.rb
@@ -15,14 +15,10 @@ class RaixHelpfulAssistant
              description: "Longitude (e.g., 52.5200)",
              required: true
            } do |arguments|
-    begin
-      url = "https://api.open-meteo.com/v1/forecast?temperature_unit=fahrenheit&latitude=#{arguments[:latitude]}&longitude=#{arguments[:longitude]}&current=temperature_2m,wind_speed_10m"
-
-      response = Faraday.get(url)
-      data = JSON.parse(response.body)
-    rescue => e
-      "Error getting weather: #{e.message}"
-    end
+    WeatherService.fetch_weather(
+      latitude: arguments[:latitude],
+      longitude: arguments[:longitude]
+    )
   end
 
   function :get_time, "Get the current time" do |_arguments|

--- a/app/models/ruby_llm_weather_tool.rb
+++ b/app/models/ruby_llm_weather_tool.rb
@@ -4,11 +4,6 @@ class RubyLlmWeatherTool < RubyLLM::Tool
   param :longitude, desc: "Longitude (e.g., 13.4050)"
 
   def execute(latitude:, longitude:)
-    url = "https://api.open-meteo.com/v1/forecast?temperature_unit=fahrenheit&latitude=#{latitude}&longitude=#{longitude}&current=temperature_2m,wind_speed_10m"
-
-    response = Faraday.get(url)
-    data = JSON.parse(response.body)
-  rescue => e
-    { error: e.message }
+    WeatherService.fetch_weather(latitude: latitude, longitude: longitude)
   end
 end

--- a/app/models/weather_service.rb
+++ b/app/models/weather_service.rb
@@ -1,0 +1,29 @@
+class WeatherService
+  API_BASE_URL = "https://api.open-meteo.com/v1/forecast"
+
+  def self.fetch_weather(latitude:, longitude:)
+    new.fetch_weather(latitude: latitude, longitude: longitude)
+  end
+
+  def fetch_weather(latitude:, longitude:)
+    url = build_url(latitude: latitude, longitude: longitude)
+
+    response = Faraday.get(url)
+    JSON.parse(response.body)
+  rescue => e
+    { error: e.message }
+  end
+
+  private
+
+  def build_url(latitude:, longitude:)
+    params = {
+      temperature_unit: "fahrenheit",
+      latitude: latitude,
+      longitude: longitude,
+      current: "temperature_2m,wind_speed_10m"
+    }
+
+    "#{API_BASE_URL}?#{URI.encode_www_form(params)}"
+  end
+end


### PR DESCRIPTION
This pull request refactors how weather data is fetched across several assistant and tool classes by introducing a shared `WeatherService`. The main benefit is to centralize the API logic, reduce code duplication, and improve maintainability. All previous direct API calls are now routed through this new service.

**Weather API logic centralization:**

* Added a new `WeatherService` class in `app/models/weather_service.rb` to encapsulate all logic for building the API URL, making the HTTP request, and handling errors. (`[app/models/weather_service.rbR1-R29](diffhunk://#diff-fc0de23d1536eaae8ddbd8cea84f78bfa64e166d0dbec4623e0ece159330ab7bR1-R29)`)

**Refactoring tool and assistant classes:**

* Updated `RaifWeatherTool`, `RaixHelpfulAssistant`, and `RubyLlmWeatherTool` to use `WeatherService.fetch_weather` instead of duplicating API request and error handling code. (`[[1]](diffhunk://#diff-50c5165e058861e1a612553bfa974bc3feda765e141274ff65f4b1b8a0b8089eL76-R78)`, `[[2]](diffhunk://#diff-47ba319e88c48e6c9479553d0c47facdcfe51a49088ab441153a9d470d7cf6d7L18-R21)`, `[[3]](diffhunk://#diff-73fc814f9f2d6b542639d5c714cf65d948a21ecb55e1475ae179007d384d7adfL7-R7)`)